### PR TITLE
Refactor pageview report logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ docker-compose up
 open http://0.0.0.0:3000
 ```
 
+The API endpoints are cached with a short 5m TTL, but Rails doesn't enable caching in the development environment by default. To enable:
+
+```bash
+docker-compose run --rm app rails dev:cache
+```
+
 ## Tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -59,3 +59,33 @@ rails t path/to/some/test.rb
 rails t path/to/some/test.rb
 # etc...
 ```
+
+## Load testing
+
+```bash
+# I was going to sort out a docker solution for this, but ran out of time/patience (yay, abstractions)
+brew install siege
+
+cd $RAILS_ROOT
+# -c50: 50 concurrent users
+# -d10: random pause between 0-10s between requests
+# -t3M: test for 3 minutes
+# -i -f: randomly select URLs from this file
+siege -c50 -d10 -t3M -i -f ./test/siege.txt
+
+# Results (on a 2011-era MBP w/ SSD)
+
+Lifting the server siege...
+Transactions:		        1770 hits
+Availability:		      100.00 %
+Elapsed time:		      179.68 secs
+Data transferred:	       32.74 MB
+Response time:		        0.07 secs
+Transaction rate:	        9.85 trans/sec
+Throughput:		        0.18 MB/sec
+Concurrency:		        0.72
+Successful transactions:        1770
+Failed transactions:	           0
+Longest transaction:	        1.71
+Shortest transaction:	        0.02
+```

--- a/app/controllers/pageviews_controller.rb
+++ b/app/controllers/pageviews_controller.rb
@@ -1,59 +1,26 @@
 class PageviewsController < ApplicationController
 
   def top_urls
-    json = json_for_date_range
-    render json: json
+    report = PageviewReport.new(
+      start_date: 5.days.ago.to_date,
+      end_date:   Date.today
+    )
+    # TODO: cache
+    results = report.call
+    render json: results
   end
 
   def top_referrers
-    json = json_for_date_range(limit: 10, referrers: true)
-    render json: json
-  end
-
-  private
-
-  def json_for_date_range(limit: nil, referrers: false)
-    json        = {}
-    start_time  = 5.days.ago.beginning_of_day
-    end_time    = Time.current.end_of_day
-    condition   = Sequel.lit('created_at BETWEEN ? AND ?', start_time, end_time)
-    pageviews   = Pageview.dataset.where(condition).group_and_count { [date(:created_at), :url] }.all
-
-    pageviews.each do |pageview|
-      key = pageview[:date].strftime('%F')
-      json[key] ||= []
-      json[key] << {
-        url:    pageview[:url],
-        visits: pageview[:count]
-      }
-    end
-
-    json.each_key do |key|
-      json[key].sort_by { |hash| hash[:visits] }.reverse!
-      if limit
-        json[key] = json[key][0, limit]
-      end
-      if referrers
-        json[key].each do |hash|
-          results = Pageview.dataset
-                            .where(created_at: key)
-                            .where(url: hash[:url])
-                            .group_and_count { [date(:created_at), :url, :referrer] }
-                            .order(Sequel.desc(:count))
-                            .limit(5)
-                            .all
-
-          hash[:referrers] = results.map do |r|
-            {
-              url:    r[:referrer],
-              visits: r[:count]
-            }
-          end
-        end
-      end
-    end
-
-    json
+    report = PageviewReport.new(
+      start_date:         5.days.ago.to_date,
+      end_date:           Date.today,
+      include_referrers:  true,
+      url_limit:          10,
+      referrer_limit:     5
+    )
+    # TODO: cache
+    results = report.call
+    render json: results
   end
 
 end

--- a/app/controllers/pageviews_controller.rb
+++ b/app/controllers/pageviews_controller.rb
@@ -5,9 +5,7 @@ class PageviewsController < ApplicationController
       start_date: 5.days.ago.to_date,
       end_date:   Date.today
     )
-    # TODO: cache
-    results = report.call
-    render json: results
+    render json: report.call
   end
 
   def top_referrers
@@ -18,9 +16,7 @@ class PageviewsController < ApplicationController
       url_limit:          10,
       referrer_limit:     5
     )
-    # TODO: cache
-    results = report.call
-    render json: results
+    render json: report.call
   end
 
 end

--- a/app/models/pageview_report.rb
+++ b/app/models/pageview_report.rb
@@ -1,0 +1,73 @@
+class PageviewReport
+  attr_reader :start_date, :end_date, :url_limit, :referrer_limit, :include_referrers
+
+  def initialize(options = {})
+    @start_date         = options[:start_date]
+    @end_date           = options[:end_date]
+    @url_limit          = options[:url_limit]
+    @referrer_limit     = options[:referrer_limit]
+    @include_referrers  = options[:include_referrers] || false
+    @pageview_data      = {}
+    validate!
+  end
+
+  def call
+    date = start_date
+    loop do
+      iso_date_string = date.strftime('%F')
+      @pageview_data[iso_date_string] = pageview_data_for_day(date)
+      date = date.advance(days: 1)
+      break if date > end_date
+    end
+    @pageview_data
+  end
+
+  private
+
+  def pageview_data_for_day(date)
+    iso_date_string = date.strftime('%F')
+    # SELECT date(created_at), url, COUNT(*) AS count
+    # FROM pageviews
+    # WHERE created_at = 'YYYY-MM-DD'
+    # GROUP BY date(created_at), url
+    # ORDER BY count DESC;
+    url_dataset = Pageview.dataset
+                          .where(created_at: iso_date_string)
+                          .group_and_count { [date(:created_at), :url] }
+                          .order(Sequel.desc(:count))
+    # respect `url_limit`
+    url_dataset = url_dataset.limit(url_limit) if url_limit
+
+    url_dataset.all.map do |url_data|
+      result = {
+        url:    url_data[:url],
+        visits: url_data[:count]
+      }
+      result[:referrers] = referrer_data_for_day(date, url_data[:url]) if include_referrers
+      result
+    end
+  end
+
+  def referrer_data_for_day(date, url)
+    iso_date_string = date.strftime('%F')
+    ref_dataset = Pageview.dataset
+                          .where(created_at: iso_date_string)
+                          .where(url: url)
+                          .group_and_count { [date(:created_at), :url, :referrer] }
+                          .order(Sequel.desc(:count))
+    ref_dataset = ref_dataset.limit(referrer_limit) if referrer_limit
+    ref_dataset.all.map do |ref_data|
+      {
+        url:    ref_data[:referrer],
+        visits: ref_data[:count]
+      }
+    end
+  end
+
+  def validate!
+    raise ArgumentError, 'Invalid start date' unless start_date.is_a?(Date)
+    raise ArgumentError, 'Invalid end date'   unless end_date.is_a?(Date)
+    raise ArgumentError, 'Invalid date range' unless start_date <= end_date
+  end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,9 @@ module WebAnalytics
       g.assets false
     end
 
+    # In production would need to switch to something like memcache or redis
+    config.cache_store = :memory_store, { size: 20.megabytes }
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/test/models/pageview_report_test.rb
+++ b/test/models/pageview_report_test.rb
@@ -1,0 +1,131 @@
+require 'test_helper'
+
+class PageviewReportTest < ActiveSupport::TestCase
+
+  describe 'PageviewReport' do
+    it 'should raise if start_date is invalid' do
+      assert_raise(ArgumentError) { PageviewReport.new(start_date: nil, end_date: Date.today) }
+      assert_raise(ArgumentError) { PageviewReport.new(start_date: 'ham', end_date: Date.today) }
+    end
+
+    it 'should raise if end_date is invalid' do
+      assert_raise(ArgumentError) { PageviewReport.new(start_date: Date.today, end_date: nil) }
+      assert_raise(ArgumentError) { PageviewReport.new(start_date: Date.today, end_date: 'ham') }
+    end
+
+    it 'should raise if start_date is after end_date' do
+      assert_raise(ArgumentError) { PageviewReport.new(start_date: Date.today, end_date: 2.days.ago.to_date) }
+    end
+
+    it 'should have sensible defaults' do
+      report = PageviewReport.new(start_date: 5.days.ago.to_date, end_date: Date.today)
+      assert_nil(report.url_limit)
+      assert_nil(report.referrer_limit)
+      assert_equal(false, report.include_referrers)
+    end
+
+    it 'should return a hash keyed by iso date' do
+      start_date = Date.new(2018, 5, 30)
+      end_date = Date.new(2018, 6, 3)
+      report = PageviewReport.new(start_date: start_date, end_date: end_date)
+      data = report.call
+      expected = %w[2018-05-30 2018-05-31 2018-06-01 2018-06-02 2018-06-03]
+      assert_equal(expected, data.keys)
+    end
+  end
+
+  describe 'PageviewReport for top urls' do
+    let(:yesterday) { Date.new(2018, 5, 29) }
+    let(:today)     { Date.new(2018, 5, 30) }
+    let(:tomorrow)  { Date.new(2018, 5, 31) }
+
+    let(:report) do
+      PageviewReport.new(start_date: today, end_date: today)
+    end
+
+    before do
+      1.times { create(:pageview, url: 'http://example.com/1', referrer: nil, created_at: today.beginning_of_day) }
+      2.times { create(:pageview, url: 'http://example.com/2', referrer: nil, created_at: today.beginning_of_day) }
+      3.times { create(:pageview, url: 'http://example.com/3', referrer: nil, created_at: today.beginning_of_day) }
+      4.times { create(:pageview, url: 'http://example.com/4', referrer: nil, created_at: today.beginning_of_day) }
+      5.times { create(:pageview, url: 'http://example.com/5', referrer: nil, created_at: today.beginning_of_day) }
+      # beyond date range
+      create(:pageview, url: 'http://example.com/wat', referrer: nil, created_at: yesterday.end_of_day)
+      create(:pageview, url: 'http://example.com/wat', referrer: nil, created_at: tomorrow.beginning_of_day)
+    end
+
+    it 'should only return data in the date range' do
+      data = report.call
+      # shouldn't include results for yesterday or tomorrow
+      assert_equal(['2018-05-30'], data.keys)
+      assert_equal(5, data['2018-05-30'].length)
+      # pageviews for each date should be ordered by visits DESC
+      assert_equal('http://example.com/5',  data['2018-05-30'][0][:url])
+      assert_equal(5,                       data['2018-05-30'][0][:visits])
+      assert_equal('http://example.com/4',  data['2018-05-30'][1][:url])
+      assert_equal(4,                       data['2018-05-30'][1][:visits])
+      assert_equal('http://example.com/3',  data['2018-05-30'][2][:url])
+      assert_equal(3,                       data['2018-05-30'][2][:visits])
+      # etc...
+    end
+  end
+
+  describe 'PageviewReport for top referrers' do
+    let(:yesterday) { Date.new(2018, 5, 29) }
+    let(:today)     { Date.new(2018, 5, 30) }
+    let(:tomorrow)  { Date.new(2018, 5, 31) }
+
+    let(:report) do
+      PageviewReport.new(
+        start_date:         today,
+        end_date:           today,
+        include_referrers:  true,
+        url_limit:          1,
+        referrer_limit:     3
+      )
+    end
+
+    before do
+      # referrer 1
+      create(:pageview, url: 'http://example.com/1', referrer: 'http://foo.com/', created_at: today.beginning_of_day)
+      create(:pageview, url: 'http://example.com/1', referrer: 'http://foo.com/', created_at: today.beginning_of_day)
+      create(:pageview, url: 'http://example.com/1', referrer: 'http://foo.com/', created_at: today.beginning_of_day)
+      create(:pageview, url: 'http://example.com/1', referrer: 'http://foo.com/', created_at: today.beginning_of_day)
+      # referrer 2
+      create(:pageview, url: 'http://example.com/1', referrer: 'http://bar.com/', created_at: today.beginning_of_day)
+      create(:pageview, url: 'http://example.com/1', referrer: 'http://bar.com/', created_at: today.beginning_of_day)
+      create(:pageview, url: 'http://example.com/1', referrer: 'http://bar.com/', created_at: today.beginning_of_day)
+      # referrer 3
+      create(:pageview, url: 'http://example.com/1', referrer: 'http://baz.com/', created_at: today.beginning_of_day)
+      create(:pageview, url: 'http://example.com/1', referrer: 'http://baz.com/', created_at: today.beginning_of_day)
+
+      # beyond `referrer_limit`, but should be counted in number of `url` visits
+      create(:pageview, url: 'http://example.com/1', referrer: 'http://wat.com/', created_at: today.beginning_of_day)
+      # beyond `url_limit`
+      create(:pageview, url: 'http://example.com/2', referrer: 'http://foo.com/', created_at: today.beginning_of_day)
+      # beyond date range
+      create(:pageview, url: 'http://example.com/wat', referrer: nil, created_at: yesterday.end_of_day)
+      create(:pageview, url: 'http://example.com/wat', referrer: nil, created_at: tomorrow.beginning_of_day)
+    end
+
+    it 'should return only top N referrers' do
+      data = report.call
+      # `url_limit` is 1, so should only include the top url from `today`
+      assert_equal(['2018-05-30'], data.keys)
+      assert_equal(1, data['2018-05-30'].length)
+      # visit count should be correct
+      assert_equal('http://example.com/1', data['2018-05-30'][0][:url])
+      assert_equal(10, data['2018-05-30'][0][:visits])
+      # referrers should respect `referrer_limit`
+      assert_equal(3, data['2018-05-30'][0][:referrers].length)
+      # referrers should be correctly ordered
+      assert_equal('http://foo.com/', data['2018-05-30'][0][:referrers][0][:url])
+      assert_equal(4,                 data['2018-05-30'][0][:referrers][0][:visits])
+      assert_equal('http://bar.com/', data['2018-05-30'][0][:referrers][1][:url])
+      assert_equal(3,                 data['2018-05-30'][0][:referrers][1][:visits])
+      assert_equal('http://baz.com/', data['2018-05-30'][0][:referrers][2][:url])
+      assert_equal(2,                 data['2018-05-30'][0][:referrers][2][:visits])
+    end
+  end
+
+end

--- a/test/siege.txt
+++ b/test/siege.txt
@@ -1,0 +1,2 @@
+http://0.0.0.0:3000/top_urls
+http://0.0.0.0:3000/top_referrers


### PR DESCRIPTION
- Move logic to `PageviewReport` class

- Cache the report data for each day, because (a) this is a prototype, and (b) people aren't likely to travel back in time and generate more 😄... if doing this for a production app, I'd probably look into fancier DB tricks (I punted on using a window function for the top referrer due to time) and/or caching just the past days w/ a longer TTL and use a much shorter one for the current day (or none at all).

- Show an example of a `siege` test to show my l33t load testing skillz, and to show that page requests that pull data straight from memory are indeed fast.

Closes #4.