### PR TITLE
Remove N+1 queries in `PageviewReport`

### DIFF
--- a/app/controllers/pageviews_controller.rb
+++ b/app/controllers/pageviews_controller.rb
@@ -2,7 +2,7 @@ class PageviewsController < ApplicationController
 
   def top_urls
     report = PageviewReport.new(
-      start_date: 5.days.ago.to_date,
+      start_date: 4.days.ago.to_date,
       end_date:   Date.today
     )
     render json: report.call
@@ -10,7 +10,7 @@ class PageviewsController < ApplicationController
 
   def top_referrers
     report = PageviewReport.new(
-      start_date:         5.days.ago.to_date,
+      start_date:         4.days.ago.to_date,
       end_date:           Date.today,
       include_referrers:  true,
       url_limit:          10,

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,9 +27,6 @@ module WebAnalytics
       g.assets false
     end
 
-    # In production would need to switch to something like memcache or redis
-    config.cache_store = :memory_store, { size: 20.megabytes }
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,8 +16,7 @@ Rails.application.configure do
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
-
-    config.cache_store = :memory_store
+    config.cache_store = :memory_store, { size: 20.megabytes }
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.web_console.whitelisted_ips = ['127.0.0.1', '172.18.0.0/16', '192.168.0.0/16']
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,8 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.cache_store = :null_store
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/docs/retrospective.md
+++ b/docs/retrospective.md
@@ -50,6 +50,13 @@ I wasn't too happy w/ how the controller looked, so I extracted the logic into a
 As one would expect, caching improved the response time of the API endpoints dramatically. I did a simple load test using `siege` (instructions in the README) and was pretty happy with the result.
 
 
+#### Addendum
+
+The N+1 queries were really bugging me. After sleeping on it, I realized I could just do some of the aggregation, sorting, and limiting in Ruby (something I've done at past gigs to reduce load on the DB):
+
+https://github.com/twelvelabs/web_analytics/pull/9
+
+
 ### [Setup front end](https://github.com/twelvelabs/web_analytics/issues/5)
 
 tktk

--- a/test/controllers/pageviews_controller_test.rb
+++ b/test/controllers/pageviews_controller_test.rb
@@ -3,21 +3,29 @@ require 'test_helper'
 class PageviewsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get top_urls' do
-    pageview = create(:pageview)
+    start_key = 4.days.ago.to_date.strftime('%F')
+    end_key   = Date.today.strftime('%F')
 
     get top_urls_url
-    json = JSON.parse(response.body)
-
     assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_equal(5, json.keys.length)
+    assert_equal(start_key, json.keys.first)
+    assert_equal(end_key, json.keys.last)
   end
 
   test 'should get top_referrers' do
-    pageview = create(:pageview)
+    start_key = 4.days.ago.to_date.strftime('%F')
+    end_key   = Date.today.strftime('%F')
 
     get top_referrers_url
-    json = JSON.parse(response.body)
-
     assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_equal(5, json.keys.length)
+    assert_equal(start_key, json.keys.first)
+    assert_equal(end_key, json.keys.last)
   end
 
 end

--- a/test/models/pageview_report_test.rb
+++ b/test/models/pageview_report_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class PageviewReportTest < ActiveSupport::TestCase
 
+  before do
+    Pageview.dataset.delete
+  end
+
   describe 'PageviewReport' do
     it 'should raise if start_date is invalid' do
       assert_raise(ArgumentError) { PageviewReport.new(start_date: nil, end_date: Date.today) }


### PR DESCRIPTION
I wasn't all that thrilled with how I was fetching referrer data in my previous iteration. This PR modifies `PageviewReport` to fetch url and referrer data in a single query, then aggregate and limit the visit counts in Ruby. It's a bit faster and easier on the DB, at the expense of sending a lot more data over the wire... ["to-may-to, to-mah-to"](https://www.youtube.com/watch?v=zZ3fjQa5Hls).

In addition, I fixed a bug in the controller where I was returning 6 days instead of 5 😬, and properly configured to only use caching in the development environment. I was accidentally caching in the tests and seeing transient test failures. That was fun.

